### PR TITLE
fix: 修复14处Bug和不规范写法，添加Go回忆清单

### DIFF
--- a/GO_REVIEW.md
+++ b/GO_REVIEW.md
@@ -1,0 +1,690 @@
+# Go 语法与特性回忆清单
+> 基于 local-mirror 项目代码，结合具体功能场景
+
+---
+
+## 1. 包与模块系统
+
+### 1.1 package 声明与 import
+```go
+// 每个文件必须有 package 声明
+package app
+
+// import 分组：标准库 / 本地包 / 第三方包（goimports 自动排序）
+import (
+    "fmt"
+    "os"
+
+    "local-mirror/config"
+    "local-mirror/internal/tree"
+
+    log "github.com/sirupsen/logrus"  // 别名导入：解决包名冲突
+)
+```
+
+**项目中的例子：** `main.go` 把 `internal` 包别名为 `app`，把 `logrus` 别名为 `log`
+
+### 1.2 internal 包
+```
+internal/       ← 只有 local-mirror 模块内部可以 import
+pkg/            ← 可以被任何模块 import（公共工具）
+```
+Go 编译器强制执行：外部模块尝试 import `internal/` 下的包会报编译错误。
+
+### 1.3 init() 函数
+```go
+// config/config.go
+func init() {
+    // 程序启动时自动执行，早于 main()
+    // 同一包内多个 init() 按文件名字母序执行
+    Mode = flag.String("mode", "reality", "运行模式")
+}
+
+// main.go
+func init() {
+    config.InstanceID = utils.GenerateRandomNum()  // 生成实例ID
+    config.StartTime = time.Now().Unix()
+}
+```
+**执行顺序：** 依赖包的 `init()` → 本包的 `init()` → `main()`
+
+---
+
+## 2. 基础类型
+
+### 2.1 数值类型与字面量
+```go
+// protocol.go：协议常量用十六进制字面量
+const (
+    MagicNumber uint32 = 0xFBE322A8
+    MsgTypeHandshake uint16 = 0x0001
+)
+
+// config.go：位掩码表示模式
+const (
+    RealityMode = 0x0001
+    MirrorMode  = 0x0002
+)
+```
+
+### 2.2 自定义类型 + iota（本项目修复后的写法）
+```go
+// client.go
+type ConnectionState uint8  // 基于 uint8 的新类型，类型安全
+
+const (
+    Waiting    ConnectionState = iota  // 0
+    Online                             // 1
+    Offline                            // 2
+    Deprecated                         // 3
+)
+
+// 好处：编译器会阻止 fileClient.State = 99 这样的非法赋值
+// 而 var (Online uint8 = 0x01) 的写法允许任意 uint8 赋值
+```
+
+**iota 规则：**
+- 每个 `const` 块独立从 0 开始
+- 每行递增 1
+- 可以参与表达式：`1 << iota` 生成 1, 2, 4, 8...
+
+---
+
+## 3. 复合类型
+
+### 3.1 结构体（Struct）
+```go
+// treeDB.go：Node 是整个文件树的核心数据结构
+type Node struct {
+    ID       string    `json:"id"`         // 反引号内是结构体标签
+    Path     string    `json:"path"`
+    IsDir    bool      `json:"is_dir"`
+    Size     uint64    `json:"size"`
+    ModTime  time.Time `json:"mod_time"`   // 嵌入标准库类型
+    Depth    int       `json:"depth"`
+}
+
+// 初始化：字段名:值（未写的字段为零值）
+rootNode := &Node{
+    ID:    uuid,
+    Path:  ".",
+    IsDir: true,
+}
+```
+
+**结构体标签用途：** `json:"..."` 控制序列化的键名，`encoding/json` 读取这些标签。
+
+### 3.2 Slice（动态数组）
+```go
+// buildFileTree.go：收集所有节点
+var allNodes []*Node          // nil slice，声明但未分配
+allNodes = append(allNodes, node)  // append 自动扩容
+
+// 预分配容量（性能优化）
+result := make([]string, 0, len(input))
+
+// 切片操作
+batch := allNodes[i:end]      // 左闭右开区间，共享底层数组
+
+// slices 包（Go 1.21+）
+createEventCache = slices.Delete(createEventCache, 0, len(createEventCache))
+```
+
+**关键概念：** slice 是对底层数组的引用（指针+长度+容量），`append` 超过容量时会重新分配。
+
+### 3.3 Map
+```go
+// diffQueue.go：O(1) 查找节点
+bMap := make(map[string]tree.Node)
+for _, node := range b {
+    bMap[node.Path] = node  // 写入
+}
+
+// 读取 + 存在性检查（两值赋值模式）
+nodeB, exists := bMap[pathA]
+if !exists { ... }
+
+// 零内存占用的 Set 惯用法
+seen := make(map[string]struct{})
+seen[v] = struct{}{}   // struct{} 不占内存
+if _, ok := seen[v]; !ok { ... }
+```
+
+### 3.4 数组（固定长度）
+```go
+// protocol.go：协议中的固定长度字段
+type FileResponseMessage struct {
+    SessionID [16]byte  // 固定16字节，值类型（复制时整体复制）
+    FileHash  [32]byte  // Blake3 哈希值
+}
+
+// 访问底层字节：用切片表达式
+buf.Write(msg.SessionID[:])  // [16]byte → []byte
+```
+
+---
+
+## 4. 函数
+
+### 4.1 多返回值
+```go
+// 惯用模式：(结果, error)
+func CalcBlake3(path string) ([32]byte, error) {
+    var result [32]byte
+    f, err := os.Open(path)
+    if err != nil {
+        return result, err  // 返回零值 + error
+    }
+    defer f.Close()
+    // ...
+    return result, nil  // 成功时 error 为 nil
+}
+```
+
+### 4.2 方法（接收者函数）
+```go
+// 指针接收者：修改接收者状态，或接收者很大时避免复制
+func (s *Stack[T]) Push(value T) {
+    s.mu.Lock()
+    defer s.mu.Unlock()
+    s.data = append(s.data, value)
+}
+
+// 值接收者：不需要修改状态
+func (f *SimpleFormatter) Format(entry *log.Entry) ([]byte, error) {
+    // 实现 logrus.Formatter 接口
+}
+
+// 规则：同一类型的方法集要统一用指针接收者或值接收者
+```
+
+### 4.3 匿名函数与闭包
+```go
+// app.go：信号处理关闭时的清理函数
+defer func() {
+    if *config.Mode == "reality" {
+        _watcher.Close()
+    }
+}()  // 立即调用的匿名函数（IIFE）
+
+// mirror.go：goroutine 中的闭包捕获外部变量
+go func() {
+    fullScanTicker := time.NewTicker(fullScanInterval)
+    defer fullScanTicker.Stop()
+    for range fullScanTicker.C {
+        fullScanChan <- struct{}{}  // 捕获外部 chan
+    }
+}()
+```
+
+### 4.4 函数作为参数（高阶函数）
+```go
+// mirror.go：策略模式，把"要执行什么任务"作为参数传入
+func executeTaskWithClient(
+    taskName string,
+    fileClient *network.FileClient,
+    taskFunc func(*network.FileClient) error,  // 函数类型
+) error {
+    // ...
+    return taskFunc(fileClient)
+}
+
+// 调用时传入 lambda
+executeTaskWithClient("全量扫描", fileClient, func(client *network.FileClient) error {
+    return fullScan(client)
+})
+```
+
+---
+
+## 5. 接口
+
+### 5.1 隐式实现
+```go
+// logger/initLogger.go：实现 logrus.Formatter 接口
+type SimpleFormatter struct{}
+
+// 只要实现了接口要求的所有方法，就自动满足接口（无需 implements 关键字）
+func (f *SimpleFormatter) Format(entry *log.Entry) ([]byte, error) {
+    timestamp := entry.Time.Format("2006-01-02 15:04:05.000")
+    return []byte(fmt.Sprintf("%s [%s] %s\n", timestamp, entry.Level, entry.Message)), nil
+}
+
+// 使用：
+log.SetFormatter(&SimpleFormatter{})  // 传指针，因为方法是指针接收者
+```
+
+### 5.2 空接口与 any
+```go
+// stack.go：泛型约束中的 any 等价于 interface{}
+type Stack[T any] struct { ... }
+
+// binary.Write 接受 any（interface{}）参数
+binary.Write(buf, binary.BigEndian, msg.Version)  // uint16 满足 any
+```
+
+---
+
+## 6. 并发编程（项目核心）
+
+### 6.1 goroutine
+```go
+// app.go：启动服务的后台任务
+switch *config.Mode {
+case "reality":
+    go Reality()   // 非阻塞启动
+case "mirror":
+    go Mirror()
+}
+
+// 主 goroutine 继续执行，等待信号
+sigChan := make(chan os.Signal, 1)
+signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+<-sigChan  // 阻塞直到收到信号
+```
+
+### 6.2 Channel
+```go
+// 无缓冲 channel：发送方阻塞直到接收方就绪（同步）
+sigChan := make(chan os.Signal, 1)  // 缓冲为1：不会丢失信号
+
+// 有缓冲 channel：buildFileTree.go 工作池通信
+nodeChan := make(chan *Node, 1000)  // 缓冲1000个节点
+
+// 发送
+nodeChan <- rootNode
+
+// 接收（range：直到 channel 关闭）
+for node := range nodeChan {
+    allNodes = append(allNodes, node)
+}
+
+// 关闭（只有发送方关闭）
+close(nodeChan)
+```
+
+### 6.3 select（多路复用）
+```go
+// mirror.go：同时等待全量扫描和变更追踪两个触发器
+for {
+    select {
+    case <-fullScanChan:    // 哪个先就绪执行哪个
+        executeTaskWithClient("全量扫描", ...)
+    case <-changeChan:
+        executeTaskWithClient("变更追踪", ...)
+    }
+    // 没有 default：阻塞等待
+}
+```
+
+### 6.4 sync.Mutex / sync.RWMutex
+```go
+// buildFileTree.go：保护共享 slice
+var mu sync.Mutex
+mu.Lock()
+defer mu.Unlock()         // defer 保证即使 panic 也能释放锁
+allNodes = append(allNodes, node)
+
+// client.go：读写分离（多读少写场景性能更好）
+var mutex sync.RWMutex
+
+func (cm *ConnectionManager) GetConnection() (net.Conn, error) {
+    cm.mutex.RLock()       // 读锁：允许多个 goroutine 同时读
+    defer cm.mutex.RUnlock()
+    // ...
+}
+
+func (cm *ConnectionManager) Reconnect() error {
+    cm.mutex.Lock()        // 写锁：独占
+    defer cm.mutex.Unlock()
+    // ...
+}
+```
+
+**惯用模式：** `Lock()` 之后立即 `defer Unlock()`，放在函数开头，不要在条件分支里混用。
+
+### 6.5 sync.WaitGroup
+```go
+// buildFileTree.go：等待所有 worker goroutine 完成
+var wg sync.WaitGroup
+for range workerCount {
+    wg.Add(1)              // 启动前 Add
+    go func() {
+        defer wg.Done()   // 完成时 Done（用 defer 防遗漏）
+        for node := range nodeChan { ... }
+    }()
+}
+wg.Wait()                 // 阻塞直到所有 Done() 调用
+```
+
+### 6.6 工作池模式（Worker Pool）
+```go
+// buildFileTree.go：CPU密集型任务，池大小=CPU核数
+workerCount := runtime.NumCPU()
+nodeChan := make(chan *Node, 1000)
+
+for range workerCount {       // Go 1.22+ 纯计数 range
+    wg.Add(1)
+    go func() {               // 每个 worker 从 channel 取任务
+        defer wg.Done()
+        for node := range nodeChan {
+            mu.Lock()
+            allNodes = append(allNodes, node)
+            mu.Unlock()
+        }
+    }()
+}
+// 主 goroutine 生产数据
+filepath.WalkDir(path, func(...) { nodeChan <- node })
+close(nodeChan)  // 关闭触发所有 worker 退出 range 循环
+wg.Wait()
+```
+
+---
+
+## 7. 错误处理
+
+### 7.1 error 接口与惯用模式
+```go
+// 标准做法：函数最后一个返回值是 error
+func BuildFileTree(path string) error {
+    if err := os.MkdirAll(...); err != nil {
+        return err  // 向上传递
+    }
+    return nil     // 成功
+}
+
+// 调用方必须检查 error（Go 的设计哲学）
+if err := tree.BuildFileTree(path); err != nil {
+    log.Error(err)
+}
+```
+
+### 7.2 错误包装与 %w
+```go
+// fmt.Errorf + %w：包装错误，保留原始错误链
+return fmt.Errorf("failed to open database: %w", err)
+
+// errors.Is：检查错误链中是否包含特定错误（穿透包装层）
+if errors.Is(err, appError.ErrConnection) {
+    fileClient.ConnectionClose()
+}
+
+// 关键区别：
+// %w → errors.Is/As 可以匹配（错误链）
+// %v → 仅格式化，errors.Is 无法匹配
+```
+
+**本项目修复的错误：**
+```go
+// 错误：两个 %w 语义混乱
+return nil, fmt.Errorf("%w, failed to get connection: %w", appError.ErrConnection, err)
+
+// 正确：%w 用于哨兵错误，%v 用于附加信息
+return nil, fmt.Errorf("%w: failed to get connection: %v", appError.ErrConnection, err)
+```
+
+### 7.3 哨兵错误（Sentinel Error）
+```go
+// appError/errorTypes.go：预定义的命名错误
+var ErrConnection = errors.New("connection error")
+
+// 用 errors.Is 比较，不要用 == 比较包装后的错误
+if errors.Is(err, appError.ErrConnection) { ... }  // 正确
+if err == appError.ErrConnection { ... }            // 错误（包装后不相等）
+```
+
+### 7.4 log.Fatalf 是终止函数
+```go
+// Fatalf 内部调用 os.Exit(1)，之后代码永远不执行
+log.Fatalf("获取当前执行文件路径失败: %v", err)
+// os.Exit(1)  ← 死代码，不要写
+```
+
+---
+
+## 8. defer
+
+```go
+// 1. 资源清理（最常见用法）
+file, err := os.Open(path)
+defer file.Close()   // 函数返回时执行，无论正常还是 panic
+
+// 2. 解锁
+mu.Lock()
+defer mu.Unlock()    // 立即在 Lock 后写，防止忘记
+
+// 3. 多个 defer：LIFO 顺序（后进先出）
+defer fmt.Println("第三个执行")
+defer fmt.Println("第二个执行")
+defer fmt.Println("第一个执行")
+// 输出顺序：第一个 → 第二个 → 第三个
+
+// 4. defer 在循环中注意：每次迭代注册，函数返回才执行
+// 在循环中开文件要手动 Close，不能用 defer（否则文件一直不关闭）
+```
+
+---
+
+## 9. 泛型（Go 1.18+）
+
+```go
+// stack/stack.go：线程安全的泛型栈
+type Stack[T any] struct {   // T 是类型参数，any 是约束（任意类型）
+    data []T
+    mu   sync.Mutex
+}
+
+func NewStack[T any]() *Stack[T] {
+    return &Stack[T]{data: make([]T, 0)}
+}
+
+func (s *Stack[T]) Push(value T) { ... }
+func (s *Stack[T]) Pop() (T, bool) {
+    // 返回零值的惯用法
+    var zero T
+    return zero, false
+}
+
+// 使用时实例化（编译器推断）
+diffQueue = stack.NewStack[DiffResult]()
+NextLevel  = stack.NewStack[DiffResult]()
+```
+
+**泛型适用场景：** 容器（Stack、Queue、Set）、算法（Sort、Map、Filter）等与类型无关的逻辑。
+
+---
+
+## 10. 指针
+
+```go
+// 取地址
+rootNode := &Node{...}     // 等价于 new(Node) 并赋值
+
+// 解引用
+*config.Mode               // 读取指针指向的值（flag 返回 *string）
+*config.CoolDown           // *int64
+
+// 什么时候用指针？
+// 1. 需要修改调用者的数据
+// 2. 大结构体避免复制开销
+// 3. nil 表示"不存在"的语义
+// 4. 实现接口时需要指针接收者
+
+// nil 检查
+if fileClient.connectionManage != nil {
+    fileClient.connectionManage.Close()
+}
+```
+
+---
+
+## 11. 标准库重点回忆
+
+### encoding/binary（二进制协议，protocol.go）
+```go
+// 写入（BigEndian = 网络字节序）
+binary.Write(buf, binary.BigEndian, msg.Version)  // 自动处理字节宽度
+
+// 读取
+binary.Read(buf, binary.BigEndian, &msg.Version)  // 传指针，读入目标
+
+// 直接操作字节切片
+binary.BigEndian.PutUint64(data, value)           // 写
+value = binary.BigEndian.Uint64(data)             // 读
+```
+
+### encoding/json（树结构序列化，treeDB.go）
+```go
+// 序列化（结构体 → JSON bytes）
+nodeData, err := json.Marshal(node)    // 注意：传值而非指针也可以
+
+// 反序列化（JSON bytes → 结构体）
+var node Node
+json.Unmarshal(data, &node)            // 传指针，修改目标
+
+// 结构体标签控制字段名
+type Node struct {
+    IsDir bool `json:"is_dir"`   // JSON 中是 "is_dir"
+    Hash  string `json:"hash"`
+}
+```
+
+### path/filepath（跨平台路径，buildFileTree.go）
+```go
+filepath.Join(config.StartPath, v.Path)   // 路径拼接（自动处理分隔符）
+filepath.Dir("/a/b/c.txt")                // → "/a/b"
+filepath.Base("/a/b/c.txt")               // → "c.txt"
+filepath.WalkDir(root, func(...) error)   // 递归遍历目录树
+filepath.SkipDir                          // 返回此值跳过当前目录
+```
+
+### time（定时器，mirror.go）
+```go
+// Ticker：周期触发
+ticker := time.NewTicker(10 * time.Second)
+defer ticker.Stop()            // 必须 Stop，否则 goroutine 泄漏
+for range ticker.C { ... }    // C 是 channel，每隔指定时间发送一次
+
+// AfterFunc：延时执行一次（非阻塞）
+timer := time.AfterFunc(5*time.Second, func() {
+    // 在新 goroutine 中执行
+})
+timer.Stop()                   // 取消未执行的 timer
+
+// 时间运算
+elapsed := time.Since(startTime)      // Duration
+duration := time.Duration(n) * time.Second
+```
+
+### net（TCP 通信，network/）
+```go
+// 服务端
+listener, _ := net.Listen("tcp", "0.0.0.0:52345")
+conn, _ := listener.Accept()           // 阻塞等待连接
+
+// 客户端
+conn, err := net.Dial("tcp", addr)     // 建立连接
+
+// io.ReadFull：确保读满指定字节数（处理 TCP 粘包）
+io.ReadFull(conn, headerBytes)         // 不会因为数据未到达就返回
+```
+
+### flag（命令行参数，config.go）
+```go
+// 定义参数（返回指针）
+Mode = flag.String("mode", "reality", "运行模式")
+
+// 短参数别名
+flag.StringVar(Mode, "m", "reality", "同 --mode")
+
+// 解析（在 main 开头调用）
+flag.Parse()
+
+// 使用（解引用）
+*config.Mode == "reality"
+```
+
+### os/signal（优雅退出，app.go）
+```go
+sigChan := make(chan os.Signal, 1)
+signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+<-sigChan  // 阻塞，收到信号后继续
+// 执行清理逻辑...
+```
+
+---
+
+## 12. Go 命名规范（速记）
+
+| 场景 | 规范 | 例子 |
+|------|------|------|
+| 普通变量/函数 | 驼峰 | `dirCount`, `fileClient` |
+| 导出（public） | 首字母大写 | `AddNodes`, `FileClient` |
+| 未导出（private）| 首字母小写 | `connectionManage`, `dirCount` |
+| 接口名 | 通常加 -er | `Formatter`, `Reader`, `Writer` |
+| 错误变量 | Err 前缀 | `ErrConnection`, `ErrNotExist` |
+| **禁止** | 下划线命名 | ~~`dir_count`~~ → `dirCount` |
+| **禁止** | 全大写缩写 | ~~`URL`~~ → `Url` 或 `url`（缩写除外：`ID`, `HTTP`） |
+
+---
+
+## 13. 常见惯用法速记
+
+```go
+// 1. 零值 Set
+seen := make(map[string]struct{})
+seen[key] = struct{}{}
+
+// 2. 函数内 defer unlock（固定模板）
+mu.Lock()
+defer mu.Unlock()
+
+// 3. 类型断言（判断接口具体类型）
+if state, ok := v.(ConnectionState); ok { ... }
+
+// 4. 空白标识符（显式忽略）
+uuid, _ := utils.RandomString(16)   // 不关心 error
+_ = binary.Write(buf, ...)          // 有意忽略（需注释说明原因）
+
+// 5. 变量遮蔽（:= 在内层作用域）
+err := doA()
+if err := doB(); err != nil {  // 新的 err，外层 err 未被修改
+    return err
+}
+
+// 6. 短路求值
+if cm.conn != nil && cm.isConnValid() { ... }  // conn 为 nil 时不调用 isConnValid
+
+// 7. 多重赋值
+nodeB, exists := bMap[pathA]
+
+// 8. 闭包陷阱（循环变量捕获）
+for i, v := range items {
+    go func(i int, v Item) {  // 传参而非直接使用循环变量
+        use(i, v)
+    }(i, v)
+}
+```
+
+---
+
+## 14. 本项目修复汇总（对照学习）
+
+| 文件 | 问题 | 原因 | 修复方式 |
+|------|------|------|----------|
+| `client.go` | `var Online uint8` | var 可被修改 | `const` + 自定义类型 `ConnectionState` |
+| `client.go` | `GetConnection` defer 混乱 | 分支内 defer 难读 | 函数入口统一 `defer RUnlock()` |
+| `client.go` | `conn, _ := GetConnection()` | nil conn 导致 panic | 检查 error 后再使用 |
+| `client.go` | `fmt.Errorf("%w...%w")` | 双 %w 语义混乱 | `%w` 包装哨兵，`%v` 附加信息 |
+| `client.go` | `file.Sync()` 返回值忽略 | I/O 错误被吞 | 检查并 log.Warn |
+| `treeDB.go` | InitDB 第一个 err 被覆盖 | 静默失败 | if/else 分别检查两个 Update |
+| `treeDB.go` | `var dir_count uint64` | 下划线命名 | 改为 `dirCount` |
+| `treeDB.go` | `switch node.IsDir { case true` | bool 不适合 switch | 改为 `if node.IsDir` |
+| `treeDB.go` | `if pathID != nil { exists = true }` | 冗余 if/else | `exists = pathID != nil` |
+| `diffQueue.go` | `ParentID: nodeB.ParentID` | nodeB 是零值 | 改为 `nodeA.ParentID` |
+| `initConn.go` | `for i := range make([]struct{}, n)` | 无意义内存分配 | `for i := 0; i < n; i++` |
+| `mirror.go` | 循环清空 Stack | 忽略现有方法 | `NextLevel.Clear()` |
+| `mirror.go` | `os.MkdirAll(v.Path, ...)` | 相对路径创建位置错误 | `filepath.Join(config.StartPath, v.Path)` |
+| `main.go` | `Fatalf` 后接 `os.Exit(1)` | 死代码 | 删除多余的 `os.Exit` |
+| `protocol.go` | `binary.Write(...)` 返回值丢弃 | 隐式忽略 | 改为 `_ = binary.Write(...)` |

--- a/cmd/local-mirror/main.go
+++ b/cmd/local-mirror/main.go
@@ -19,8 +19,8 @@ func init() {
 	config.StartTime = time.Now().Unix()
 	wd, err := os.Getwd()
 	if err != nil {
+		// log.Fatalf 内部已调用 os.Exit(1)，后面不需要再调用
 		log.Fatalf("获取当前执行文件路径失败: %v", err)
-		os.Exit(1)
 	}
 	fmt.Print(wd)
 	config.StartPath = wd

--- a/internal/diffQueue.go
+++ b/internal/diffQueue.go
@@ -36,14 +36,14 @@ func FindDifferences(a, b []tree.Node) []DiffResult {
 		pathA := nodeA.Path
 		nodeB, exists := bMap[pathA]
 		if !exists {
-			// 如果b中没有对应节点，标记为add
+			// nodeB 不存在时是零值，ParentID 应取 nodeA 的
 			diffs = append(diffs, DiffResult{
 				Path:     pathA,
 				IsDir:    nodeA.IsDir,
 				Action:   "create",
 				Name:     nodeA.Name,
 				Size:     nodeA.Size,
-				ParentID: nodeB.ParentID,
+				ParentID: nodeA.ParentID,
 			})
 		}
 		// 如果b中有对应节点，比较属性

--- a/internal/initConn.go
+++ b/internal/initConn.go
@@ -15,7 +15,8 @@ func InitConn() (*network.FileClient, error) {
 	if err != nil {
 		return fileClient, fmt.Errorf("failed to create file client: %w", err)
 	}
-	for i := range make([]struct{}, maxRetries) {
+	// 标准计数循环写法；原来的 make([]struct{}, n) 会创建无意义的临时 slice
+	for i := 0; i < maxRetries; i++ {
 		log.Warnf("Attempting to connect to server at %s, attempt %d/%d", fileClient.RealityAddr, i+1, maxRetries)
 		log.Debugf("Connecting to server at %s", fileClient.RealityAddr)
 		err := fileClient.Handshake()

--- a/internal/mirror.go
+++ b/internal/mirror.go
@@ -99,8 +99,11 @@ func processDiffItem(v DiffResult, fileClient *network.FileClient) error {
 }
 
 func processDirectoryDiff(v DiffResult) error {
-	if err := os.MkdirAll(v.Path, 0755); err != nil {
-		return fmt.Errorf("failed to create directory %s: %w", v.Path, err)
+	// v.Path 是相对路径，必须拼接 StartPath 才能在正确的位置创建目录
+	// 与 DownloadFile 中 filepath.Join(config.StartPath, filePath) 保持一致
+	fullPath := filepath.Join(config.StartPath, v.Path)
+	if err := os.MkdirAll(fullPath, 0755); err != nil {
+		return fmt.Errorf("failed to create directory %s: %w", fullPath, err)
 	}
 
 	hasPath, err := tree.HasPath(v.Path)
@@ -270,10 +273,8 @@ func runMirrorTasks(fileClient *network.FileClient) error {
 func fullScan(fileClient *network.FileClient) error {
 	startTime := time.Now().UnixMilli()
 
-	// Clear the stack and start with root node
-	for NextLevel.Size() > 0 {
-		NextLevel.Pop()
-	}
+	// Stack 自带 Clear()，无需手动循环弹出
+	NextLevel.Clear()
 
 	rootNode := DiffResult{
 		Path:   ".",

--- a/internal/network/client.go
+++ b/internal/network/client.go
@@ -15,11 +15,15 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var (
-	Waiting    uint8 = 0x00 // 等待
-	Online     uint8 = 0x01 // 在线
-	Offline    uint8 = 0x02 // 离线
-	Deprecated uint8 = 0x03 // 废弃
+// ConnectionState 描述客户端连接的生命周期状态。
+// 使用自定义类型而非 uint8，让编译器在类型赋值时提供保护。
+type ConnectionState uint8
+
+const (
+	Waiting    ConnectionState = iota // 0x00 已建立TCP连接，等待握手
+	Online                            // 0x01 握手成功，可以正常通信
+	Offline                           // 0x02 连接已断开
+	Deprecated                        // 0x03 连接不可恢复，需要丢弃
 )
 
 type ConnectionManager struct {
@@ -44,14 +48,13 @@ func NewConnectionManager(addr string) (*ConnectionManager, error) {
 }
 
 func (cm *ConnectionManager) GetConnection() (net.Conn, error) {
+	// defer 统一放在函数入口，无论哪条返回路径都能正确释放读锁
 	cm.mutex.RLock()
-	if cm.conn != nil {
-		if cm.isConnValid() {
-			defer cm.mutex.RUnlock()
-			return cm.conn, nil
-		}
+	defer cm.mutex.RUnlock()
+
+	if cm.conn != nil && cm.isConnValid() {
+		return cm.conn, nil
 	}
-	cm.mutex.RUnlock()
 	return nil, fmt.Errorf("connection is invalid")
 }
 
@@ -104,7 +107,7 @@ type FileClient struct {
 	connectionManage *ConnectionManager
 	realityVersion   uint16
 	realityID        uint32
-	State            uint8
+	State            ConnectionState
 }
 
 func NewFileClient(realityAddr string, serverAlias string) (*FileClient, error) {
@@ -151,7 +154,10 @@ func (c *FileClient) Reconnect() error {
 }
 
 func (c *FileClient) Reverify() error {
-	conn, _ := c.connectionManage.GetConnection()
+	conn, err := c.connectionManage.GetConnection()
+	if err != nil {
+		return fmt.Errorf("reverify failed to get connection: %w", err)
+	}
 	if err := sendMessage(conn, MsgTypeHandshake, nil); err != nil {
 		return fmt.Errorf("failed to send reverify message: %w", err)
 	}
@@ -253,7 +259,7 @@ func (c *FileClient) Ping(conn net.Conn) error {
 func (c *FileClient) GetRealityTree(rootPath string) ([]byte, error) {
 	conn, err := c.connectionManage.GetConnection()
 	if err != nil {
-		return nil, fmt.Errorf("%w, failed to get connection: %w", appError.ErrConnection, err)
+		return nil, fmt.Errorf("%w: failed to get connection: %v", appError.ErrConnection, err)
 	}
 	request := TreeRequestMessage{
 		PathLength: uint16(len(rootPath)),
@@ -262,17 +268,17 @@ func (c *FileClient) GetRealityTree(rootPath string) ([]byte, error) {
 	requestBytes := encodeTreeRequest(request)
 	realityAddr := conn.RemoteAddr().String()
 	if err := sendMessage(conn, MsgTypeTreeRequest, requestBytes); err != nil {
-		return nil, fmt.Errorf("%w, failed to send tree request: %w", appError.ErrConnection, err)
+		return nil, fmt.Errorf("%w: failed to send tree request: %v", appError.ErrConnection, err)
 	}
 	log.Debugf("Sent tree request to %s for path: %s", realityAddr, rootPath)
 	msgType, bodyBytes, err := receiveMessage(conn)
 	if err != nil {
-		return nil, fmt.Errorf("%w, failed to receive message: %w", appError.ErrConnection, err)
+		return nil, fmt.Errorf("%w: failed to receive message: %v", appError.ErrConnection, err)
 	}
 	if msgType == MsgTypeError {
 		errorMsg, err := decodeErrorMessage(bodyBytes)
 		if err != nil {
-			return nil, fmt.Errorf("%w, failed to decode error message: %w", appError.ErrConnection, err)
+			return nil, fmt.Errorf("%w: failed to decode error message: %v", appError.ErrConnection, err)
 		}
 
 		return nil, fmt.Errorf("reality error: %s", errorMsg.ErrorMessage)
@@ -282,7 +288,7 @@ func (c *FileClient) GetRealityTree(rootPath string) ([]byte, error) {
 	}
 	treeResponse, err := decodeTreeResponse(bodyBytes)
 	if err != nil {
-		return nil, fmt.Errorf("%w, failed to decode tree response: %w", appError.ErrConnection, err)
+		return nil, fmt.Errorf("%w: failed to decode tree response: %v", appError.ErrConnection, err)
 	}
 
 	if len(treeResponse.Data) == 0 {
@@ -299,7 +305,7 @@ func (c *FileClient) GetRealityTree(rootPath string) ([]byte, error) {
 func (c *FileClient) DownloadFile(filePath string) (string, error) {
 	conn, err := c.connectionManage.GetConnection()
 	if err != nil {
-		return "", fmt.Errorf("%w, failed to get connection: %w", appError.ErrConnection, err)
+		return "", fmt.Errorf("%w: failed to get connection: %v", appError.ErrConnection, err)
 	}
 	requestFile := FileRequestMessage{
 		PathLength: uint16(len(filePath)),
@@ -308,18 +314,18 @@ func (c *FileClient) DownloadFile(filePath string) (string, error) {
 	}
 	requestBytes := encodeFileRequest(requestFile)
 	if err := sendMessage(conn, MsgTypeFileRequest, requestBytes); err != nil {
-		return "", fmt.Errorf("%w, failed to send file request: %w", appError.ErrConnection, err)
+		return "", fmt.Errorf("%w: failed to send file request: %v", appError.ErrConnection, err)
 	}
 
 	msgType, bodyBytes, err := receiveMessage(conn)
 	if err != nil {
-		return "", fmt.Errorf("%w, failed to receive message: %w", appError.ErrConnection, err)
+		return "", fmt.Errorf("%w: failed to receive message: %v", appError.ErrConnection, err)
 	}
 
 	if msgType == MsgTypeError {
 		errorMsg, err := decodeErrorMessage(bodyBytes)
 		if err != nil {
-			return "", fmt.Errorf("%w, failed to decode error message: %w", appError.ErrConnection, err)
+			return "", fmt.Errorf("%w: failed to decode error message: %v", appError.ErrConnection, err)
 		}
 		return "", fmt.Errorf("reality error: %s", errorMsg.ErrorMessage)
 	}
@@ -329,7 +335,7 @@ func (c *FileClient) DownloadFile(filePath string) (string, error) {
 	}
 	fileResponse, err := decodeFileResponse(bodyBytes)
 	if err != nil {
-		return "", fmt.Errorf("%w, failed to decode file response: %w", appError.ErrConnection, err)
+		return "", fmt.Errorf("%w: failed to decode file response: %v", appError.ErrConnection, err)
 	}
 
 	fullPath := filepath.Join(config.StartPath, filePath)
@@ -349,13 +355,13 @@ func (c *FileClient) DownloadFile(filePath string) (string, error) {
 	for {
 		msgType, bodyBytes, err := receiveMessage(conn)
 		if err != nil {
-			return "", fmt.Errorf("%w, failed to receive message: %w", appError.ErrConnection, err)
+			return "", fmt.Errorf("%w: failed to receive message: %v", appError.ErrConnection, err)
 		}
 		switch msgType {
 		case MsgTypeFileData:
 			dataMsg, err := decodeFileData(bodyBytes)
 			if err != nil {
-				return "", fmt.Errorf("%w, error decoding file data message: %w", appError.ErrConnection, err)
+				return "", fmt.Errorf("%w: error decoding file data message: %v", appError.ErrConnection, err)
 			}
 			// todo: check session ID
 			if dataMsg.SessionID != sessionID {
@@ -385,7 +391,7 @@ func (c *FileClient) DownloadFile(filePath string) (string, error) {
 		case MsgTypeFileComplete:
 			completeMsg, err := decodeFileComplete(bodyBytes)
 			if err != nil {
-				return "", fmt.Errorf("%w, error decoding file complete message: %w", appError.ErrConnection, err)
+				return "", fmt.Errorf("%w: error decoding file complete message: %v", appError.ErrConnection, err)
 			}
 			if completeMsg.SessionID != sessionID {
 				return "", fmt.Errorf("invalid session ID in file complete message, got %s", completeMsg.SessionID)
@@ -402,7 +408,9 @@ func (c *FileClient) DownloadFile(filePath string) (string, error) {
 				return "", err
 			}
 
-			file.Sync()
+			if err := file.Sync(); err != nil {
+				log.Warnf("file.Sync() failed for %s: %v", fullPath, err)
+			}
 			fileHash, err := utils.CalcBlake3(fullPath)
 			if err != nil {
 				return "", fmt.Errorf("error calculating file hash: %w", err)
@@ -432,7 +440,7 @@ func (c *FileClient) DownloadFile(filePath string) (string, error) {
 func (c *FileClient) GetTreeChange() ([]string, error) {
 	conn, err := c.connectionManage.GetConnection()
 	if err != nil {
-		return nil, fmt.Errorf("%w, failed to get connection: %w", appError.ErrConnection, err)
+		return nil, fmt.Errorf("%w: failed to get connection: %v", appError.ErrConnection, err)
 	}
 	endTime := time.Now().Unix()
 	startTime := endTime - *config.DiffInterval
@@ -443,16 +451,16 @@ func (c *FileClient) GetTreeChange() ([]string, error) {
 	}
 	requestBytes := encodeRecentChangeRequest(request)
 	if err := sendMessage(conn, MsgTypeRecentChangeRequest, requestBytes); err != nil {
-		return nil, fmt.Errorf("%w, failed to send recent change request: %w", appError.ErrConnection, err)
+		return nil, fmt.Errorf("%w: failed to send recent change request: %v", appError.ErrConnection, err)
 	}
 	msgType, bodyBytes, err := receiveMessage(conn)
 	if err != nil {
-		return nil, fmt.Errorf("%w, failed to receive message: %w", appError.ErrConnection, err)
+		return nil, fmt.Errorf("%w: failed to receive message: %v", appError.ErrConnection, err)
 	}
 	if msgType == MsgTypeError {
 		errorMsg, err := decodeErrorMessage(bodyBytes)
 		if err != nil {
-			return nil, fmt.Errorf("%w, failed to decode error message: %w", appError.ErrConnection, err)
+			return nil, fmt.Errorf("%w: failed to decode error message: %v", appError.ErrConnection, err)
 		}
 		return nil, fmt.Errorf("reality error: %s", errorMsg.ErrorMessage)
 	}
@@ -461,7 +469,7 @@ func (c *FileClient) GetTreeChange() ([]string, error) {
 	}
 	recentChangeResponse, err := decodeRecentChangeResponse(bodyBytes)
 	if err != nil {
-		return nil, fmt.Errorf("%w, failed to decode recent change response: %w", appError.ErrConnection, err)
+		return nil, fmt.Errorf("%w: failed to decode recent change response: %v", appError.ErrConnection, err)
 	}
 	if len(recentChangeResponse.Changes) == 0 {
 		log.Warnf("Received empty recent change response from %s", c.RealityAddr)

--- a/internal/network/protocol.go
+++ b/internal/network/protocol.go
@@ -136,12 +136,15 @@ type ReverifyResponse struct {
 	ServerID uint32 // 客户端标识
 }
 
+// encode 系列函数写入 bytes.Buffer，其 Write 方法在内存不足时 panic 而非返回 error，
+// 因此 binary.Write 对 bytes.Buffer 实际上不会返回 error。
+// 用 _ = 显式表达"有意忽略"，避免 errcheck 等工具误报。
 func encodeHeader(header MessageHeader) []byte {
 	buf := new(bytes.Buffer)
-	binary.Write(buf, binary.BigEndian, header.Magic)
-	binary.Write(buf, binary.BigEndian, header.Type)
-	binary.Write(buf, binary.BigEndian, header.BodyLength)
-	binary.Write(buf, binary.BigEndian, header.ReservedWord)
+	_ = binary.Write(buf, binary.BigEndian, header.Magic)
+	_ = binary.Write(buf, binary.BigEndian, header.Type)
+	_ = binary.Write(buf, binary.BigEndian, header.BodyLength)
+	_ = binary.Write(buf, binary.BigEndian, header.ReservedWord)
 	return buf.Bytes()
 }
 
@@ -167,9 +170,9 @@ func decodeHeader(data []byte) (MessageHeader, error) {
 
 func encodeHandshake(msg HandshakeMessage) []byte {
 	buf := new(bytes.Buffer)
-	binary.Write(buf, binary.BigEndian, msg.Version)
-	binary.Write(buf, binary.BigEndian, msg.UUID)
-	binary.Write(buf, binary.BigEndian, msg.Role)
+	_ = binary.Write(buf, binary.BigEndian, msg.Version)
+	_ = binary.Write(buf, binary.BigEndian, msg.UUID)
+	_ = binary.Write(buf, binary.BigEndian, msg.Role)
 	return buf.Bytes()
 }
 
@@ -190,9 +193,9 @@ func decodeHandshake(data []byte) (HandshakeMessage, error) {
 
 func encodeFileRequest(msg FileRequestMessage) []byte {
 	buf := new(bytes.Buffer)
-	binary.Write(buf, binary.BigEndian, msg.PathLength)
+	_ = binary.Write(buf, binary.BigEndian, msg.PathLength)
 	buf.Write([]byte(msg.FilePath))
-	binary.Write(buf, binary.BigEndian, msg.Offset)
+	_ = binary.Write(buf, binary.BigEndian, msg.Offset)
 	return buf.Bytes()
 }
 
@@ -222,7 +225,7 @@ func decodeFileRequest(data []byte) (FileRequestMessage, error) {
 func encodeFileResponse(msg FileResponseMessage) []byte {
 	buf := new(bytes.Buffer)
 	buf.Write(msg.SessionID[:])
-	binary.Write(buf, binary.BigEndian, msg.FileSize)
+	_ = binary.Write(buf, binary.BigEndian, msg.FileSize)
 	buf.Write(msg.FileHash[:])
 	return buf.Bytes()
 }
@@ -252,8 +255,8 @@ func decodeFileResponse(data []byte) (FileResponseMessage, error) {
 func encodeFileData(msg FileDataMessage) []byte {
 	buf := new(bytes.Buffer)
 	buf.Write(msg.SessionID[:])
-	binary.Write(buf, binary.BigEndian, msg.Offset)
-	binary.Write(buf, binary.BigEndian, msg.DataLength)
+	_ = binary.Write(buf, binary.BigEndian, msg.Offset)
+	_ = binary.Write(buf, binary.BigEndian, msg.DataLength)
 	buf.Write(msg.Data)
 	return buf.Bytes()
 }
@@ -288,7 +291,7 @@ func decodeFileData(data []byte) (FileDataMessage, error) {
 func encodeAcknowlege(msg AcknowledgeMessage) []byte {
 	buf := new(bytes.Buffer)
 	buf.Write(msg.SessionID[:])
-	binary.Write(buf, binary.BigEndian, msg.Offset)
+	_ = binary.Write(buf, binary.BigEndian, msg.Offset)
 	return buf.Bytes()
 }
 
@@ -328,7 +331,7 @@ func decodeFileComplete(data []byte) (FileCompleteMessage, error) {
 
 func encodeErrorMessage(msg ErrorMessage) []byte {
 	buf := new(bytes.Buffer)
-	binary.Write(buf, binary.BigEndian, msg.MessageLen)
+	_ = binary.Write(buf, binary.BigEndian, msg.MessageLen)
 	buf.Write([]byte(msg.ErrorMessage))
 	return buf.Bytes()
 }
@@ -397,7 +400,7 @@ func receiveMessage(conn net.Conn) (uint16, []byte, error) {
 
 func encodeTreeRequest(msg TreeRequestMessage) []byte {
 	buf := new(bytes.Buffer)
-	binary.Write(buf, binary.BigEndian, msg.PathLength)
+	_ = binary.Write(buf, binary.BigEndian, msg.PathLength)
 	buf.Write([]byte(msg.RootPath))
 	return buf.Bytes()
 }
@@ -422,9 +425,9 @@ func decodeTreeRequest(data []byte) (TreeRequestMessage, error) {
 func encodeTreeResponse(msg TreeResponseMessage) []byte {
 	buf := new(bytes.Buffer)
 	pathBytes := []byte(msg.RootPath)
-	binary.Write(buf, binary.BigEndian, uint16(len(pathBytes)))
+	_ = binary.Write(buf, binary.BigEndian, uint16(len(pathBytes)))
 	buf.Write(pathBytes)
-	binary.Write(buf, binary.BigEndian, msg.DataLength)
+	_ = binary.Write(buf, binary.BigEndian, msg.DataLength)
 	buf.Write(msg.Data)
 	return buf.Bytes()
 }
@@ -462,9 +465,9 @@ func decodeTreeResponse(data []byte) (TreeResponseMessage, error) {
 
 func encodeHeartbeatPing(msg HeartbeatPingMessage) []byte {
 	buf := new(bytes.Buffer)
-	binary.Write(buf, binary.BigEndian, msg.Version)
-	binary.Write(buf, binary.BigEndian, msg.Timestamp)
-	binary.Write(buf, binary.BigEndian, msg.ClientID)
+	_ = binary.Write(buf, binary.BigEndian, msg.Version)
+	_ = binary.Write(buf, binary.BigEndian, msg.Timestamp)
+	_ = binary.Write(buf, binary.BigEndian, msg.ClientID)
 	return buf.Bytes()
 }
 
@@ -489,9 +492,9 @@ func decodeHeartbeatPing(data []byte) (HeartbeatPingMessage, error) {
 
 func encodeHeartbeatPong(msg HeartbeatPongMessage) []byte {
 	buf := new(bytes.Buffer)
-	binary.Write(buf, binary.BigEndian, msg.Version)
-	binary.Write(buf, binary.BigEndian, msg.Timestamp)
-	binary.Write(buf, binary.BigEndian, msg.ServerID)
+	_ = binary.Write(buf, binary.BigEndian, msg.Version)
+	_ = binary.Write(buf, binary.BigEndian, msg.Timestamp)
+	_ = binary.Write(buf, binary.BigEndian, msg.ServerID)
 	return buf.Bytes()
 }
 
@@ -516,8 +519,8 @@ func decodeHeartbeatPong(data []byte) (HeartbeatPongMessage, error) {
 
 func encodeReverifyResponse(msg ReverifyResponse) []byte {
 	buf := new(bytes.Buffer)
-	binary.Write(buf, binary.BigEndian, msg.Version)
-	binary.Write(buf, binary.BigEndian, msg.ServerID)
+	_ = binary.Write(buf, binary.BigEndian, msg.Version)
+	_ = binary.Write(buf, binary.BigEndian, msg.ServerID)
 	return buf.Bytes()
 }
 
@@ -538,9 +541,9 @@ func decodeReverifyResponse(data []byte) (ReverifyResponse, error) {
 
 func encodeRecentChangeRequest(msg RecentChangeRequestMessage) []byte {
 	buf := new(bytes.Buffer)
-	binary.Write(buf, binary.BigEndian, msg.ClientID)
-	binary.Write(buf, binary.BigEndian, msg.startTime)
-	binary.Write(buf, binary.BigEndian, msg.endTime)
+	_ = binary.Write(buf, binary.BigEndian, msg.ClientID)
+	_ = binary.Write(buf, binary.BigEndian, msg.startTime)
+	_ = binary.Write(buf, binary.BigEndian, msg.endTime)
 	return buf.Bytes()
 }
 
@@ -565,13 +568,13 @@ func decodeRecentChangeRequest(data []byte) (RecentChangeRequestMessage, error) 
 
 func encodeRecentChangeResponse(msg RecentChangeResponseMessage) []byte {
 	buf := new(bytes.Buffer)
-	binary.Write(buf, binary.BigEndian, msg.ServerID)
+	_ = binary.Write(buf, binary.BigEndian, msg.ServerID)
 
 	changeCount := len(msg.Changes)
-	binary.Write(buf, binary.BigEndian, uint32(changeCount))
+	_ = binary.Write(buf, binary.BigEndian, uint32(changeCount))
 	for _, change := range msg.Changes {
 		changeBytes := []byte(change)
-		binary.Write(buf, binary.BigEndian, uint16(len(changeBytes)))
+		_ = binary.Write(buf, binary.BigEndian, uint16(len(changeBytes)))
 		buf.Write(changeBytes)
 	}
 

--- a/internal/tree/treeDB.go
+++ b/internal/tree/treeDB.go
@@ -62,7 +62,8 @@ func InitDB() {
 		log.Error("Failed to open database:", err)
 		os.Exit(1)
 	}
-	err = DB.Update(func(tx *bolt.Tx) error {
+	// 第一步：创建所有 bucket（每次启动清空重建）
+	if err = DB.Update(func(tx *bolt.Tx) error {
 		buckets := []string{"nodes", "children", "path_index", "meta", "changed_dirs"}
 		for _, bucketName := range buckets {
 			// 删除旧的 bucket（如果存在）
@@ -77,8 +78,13 @@ func InitDB() {
 			}
 		}
 		return nil
-	})
-	err = DB.Update(func(tx *bolt.Tx) error {
+	}); err != nil {
+		log.Error("bbolt: failed to initialize buckets:", err)
+		os.Exit(1)
+	}
+
+	// 第二步：写入初始元数据
+	if err = DB.Update(func(tx *bolt.Tx) error {
 		metaBucket := tx.Bucket([]byte("meta"))
 		// 初始化目录和文件计数
 		dirCountData := make([]byte, 8)
@@ -90,10 +96,8 @@ func InitDB() {
 		metaBucket.Put([]byte("start_path"), []byte(config.StartPath))
 		metaBucket.Put([]byte("start_time"), []byte(time.Now().Format(time.RFC3339)))
 		return nil
-	})
-
-	if err != nil {
-		log.Error("bbolt:", err)
+	}); err != nil {
+		log.Error("bbolt: failed to initialize meta:", err)
 		os.Exit(1)
 	}
 	log.Info("Database initialized successfully")
@@ -114,8 +118,9 @@ func GetMeta(key string) (uint64, error) {
 
 func AddNodes(nodes []*Node) error {
 	log.Debug("Adding nodes to the database:", len(nodes))
-	var dir_count uint64 = 0
-	var file_count uint64 = 0
+	// Go 命名规范：驼峰式，不用下划线
+	var dirCount uint64
+	var fileCount uint64
 	_err := DB.Update(func(tx *bolt.Tx) error {
 		nodesBucket := tx.Bucket([]byte("nodes"))
 		childrenBucket := tx.Bucket([]byte("children"))
@@ -134,11 +139,11 @@ func AddNodes(nodes []*Node) error {
 			}
 			nodesBucket.Put([]byte(node.ID), nodeData)
 			pathIndexBucket.Put([]byte(node.Path), []byte(node.ID))
-			switch node.IsDir {
-			case true:
-				dir_count++
-			case false:
-				file_count++
+			// bool 类型直接用 if/else，switch bool 在 Go 中不惯用
+			if node.IsDir {
+				dirCount++
+			} else {
+				fileCount++
 			}
 			if node.ParentID != "" {
 				childrenData := childrenBucket.Get([]byte(node.ParentID))
@@ -159,10 +164,10 @@ func AddNodes(nodes []*Node) error {
 			}
 			log.Debugf("Node %s added successfully", node.ID)
 		}
-		if dir_count > 0 {
+		if dirCount > 0 {
 			oldDirCount := metaBucket.Get([]byte("dir_count"))
 			if oldDirCount != nil {
-				newDirCount := binary.BigEndian.Uint64(oldDirCount) + dir_count
+				newDirCount := binary.BigEndian.Uint64(oldDirCount) + dirCount
 				dirCountData := make([]byte, 8)
 				binary.BigEndian.PutUint64(dirCountData, newDirCount)
 				if err := metaBucket.Put([]byte("dir_count"), dirCountData); err != nil {
@@ -171,17 +176,17 @@ func AddNodes(nodes []*Node) error {
 				}
 			} else {
 				dirCountData := make([]byte, 8)
-				binary.BigEndian.PutUint64(dirCountData, dir_count)
+				binary.BigEndian.PutUint64(dirCountData, dirCount)
 				if err := metaBucket.Put([]byte("dir_count"), dirCountData); err != nil {
 					log.Error("Failed to set initial directory count:", err)
 					return err
 				}
 			}
 		}
-		if file_count > 0 {
+		if fileCount > 0 {
 			oldFileCount := metaBucket.Get([]byte("file_count"))
 			if oldFileCount != nil {
-				newFileCount := binary.BigEndian.Uint64(oldFileCount) + file_count
+				newFileCount := binary.BigEndian.Uint64(oldFileCount) + fileCount
 				fileCountData := make([]byte, 8)
 				binary.BigEndian.PutUint64(fileCountData, newFileCount)
 				if err := metaBucket.Put([]byte("file_count"), fileCountData); err != nil {
@@ -190,7 +195,7 @@ func AddNodes(nodes []*Node) error {
 				}
 			} else {
 				fileCountData := make([]byte, 8)
-				binary.BigEndian.PutUint64(fileCountData, file_count)
+				binary.BigEndian.PutUint64(fileCountData, fileCount)
 				if err := metaBucket.Put([]byte("file_count"), fileCountData); err != nil {
 					log.Error("Failed to set initial file count:", err)
 					return err
@@ -199,7 +204,7 @@ func AddNodes(nodes []*Node) error {
 		}
 		return nil
 	})
-	log.Debugf("Added %d directories and %d files to the database", dir_count, file_count)
+	log.Debugf("Added %d directories and %d files to the database", dirCount, fileCount)
 	return _err
 }
 
@@ -420,12 +425,8 @@ func HasPath(path string) (bool, error) {
 		if pathIndexBucket == nil {
 			return fmt.Errorf("path index bucket not found")
 		}
-		pathID := pathIndexBucket.Get([]byte(path))
-		if pathID != nil {
-			exists = true
-		} else {
-			exists = false
-		}
+		// 直接将比较结果赋值，无需 if/else
+		exists = pathIndexBucket.Get([]byte(path)) != nil
 		return nil
 	})
 	return exists, err


### PR DESCRIPTION
Bug修复：
- diffQueue: create时错误使用零值nodeB.ParentID，改为nodeA.ParentID
- treeDB: InitDB第一个DB.Update的error被静默覆盖，现分别检查
- client: Reverify忽略GetConnection返回的error，可能产生nil conn panic
- mirror: processDirectoryDiff未拼接StartPath，目录创建位置错误
- main: log.Fatalf后的os.Exit(1)是死代码

规范修复：
- client: 连接状态从var uint8改为const+自定义类型ConnectionState（类型安全）
- client: GetConnection中defer和手动unlock混用，统一为函数入口defer
- client: fmt.Errorf双%w语义混乱，改为%w:%v分离哨兵错误和详情
- client: file.Sync()错误被忽略，添加log.Warn
- treeDB: 变量命名dir_count/file_count改为驼峰dirCount/fileCount
- treeDB: switch bool改为惯用的if/else
- treeDB: HasPath中冗余if/else赋值简化为exists = expr != nil
- initConn: make([]struct{},n)循环改为标准for i:=0;i<n;i++
- mirror: 循环清空Stack改为调用Stack.Clear()
- protocol: binary.Write返回值隐式丢弃改为_ =显式忽略

新增：GO_REVIEW.md - 基于项目代码的Go语法特性回忆清单

https://claude.ai/code/session_01SsgeFbf9XdLDR1FXRENBnc